### PR TITLE
docs: rework agent instructions for progressive disclosure, complete the README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md — `@spearwolf/signalize`
 
-Architecture and conventions reference for AI coding agents. For Claude Code-specific operational guidance see `CLAUDE.md`. For human contributor docs see `CONTRIBUTING.md`.
+Architecture and conventions reference for AI coding agents working **on** this repository. It is the canonical, standalone description of the codebase; `CLAUDE.md` keeps only a resident subset of it. Human contributor docs are in `CONTRIBUTING.md`.
+
+Working **with** signalize as a consumer is a different job — that is the `skills/using-signalize/` skill (mental model, pitfalls, patterns), which also ships in the npm package.
 
 ## What it is
 
@@ -158,9 +160,7 @@ Subscribe-on-read happens inside `EffectImpl.whenSignalIsRead` (single subscript
 | `pnpm checkPkgTypes` | `attw --pack` package types audit |
 | `pnpm dist` | clean + compile + bundle (no test) |
 
-### CI vs local
-
-`.github/workflows/ci.yml` runs `pnpm check && pnpm test` — **not** `pnpm cbt`. To match CI locally use `pnpm world`. `pnpm cbt` skips `check`. Tooling is **Biome 2.x** (replaced ESLint + Prettier in v0.28).
+`.github/workflows/ci.yml` runs `pnpm check && pnpm test`, so `pnpm world` is the command that matches CI — `pnpm cbt` skips `check`. Tooling is **Biome 2.x** (replaced ESLint + Prettier in v0.28).
 
 ## Repo conventions
 
@@ -191,6 +191,11 @@ Subscribe-on-read happens inside `EffectImpl.whenSignalIsRead` (single subscript
 | `docs/api.md` | Complete API reference with all options |
 | `docs/recipes.md` | Patterns, quirks, gotchas |
 | `docs/cheat-sheet.md` | One-page lookup |
+| `skills/using-signalize/` | Agent skill for *consumers* — lean `SKILL.md` plus `references/{api,pitfalls,patterns}.md` loaded on demand |
 | `CHANGELOG.md` | Version history + migration notes |
 
-When the public API changes, sync in this order: source JSDoc → `docs/api.md` → `docs/recipes.md` (when a quirk/pattern is involved) → `docs/cheat-sheet.md` → `README.md` "API at a glance" → `CHANGELOG.md` "Unreleased". Older doc filenames (`introduction.md`, `guide.md`, `full-api.md`) were superseded — do not recreate them. A previous top-level `skills/` folder was removed (commit `f08fb05`); ignore any stale references.
+When the public API changes, sync in this order: source JSDoc → `docs/api.md` → `docs/recipes.md` (when a quirk/pattern is involved) → `docs/cheat-sheet.md` → `skills/using-signalize/` → `README.md` "API at a glance" → `CHANGELOG.md` "Unreleased".
+
+For the skill, keep `SKILL.md` lean — it carries the mental model, the six silently-wrong behaviours, and the pointer table. New API detail belongs in `references/api.md`, new quirks in `references/pitfalls.md`, new idioms in `references/patterns.md`. A quirk graduates into `SKILL.md` only when it is both common and silent.
+
+Older doc filenames (`introduction.md`, `guide.md`, `full-api.md`) were superseded — do not recreate them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `README.md`: install snippet now installs the `@spearwolf/eventize` peer dependency explicitly (pnpm/yarn do not add peers), and notes the ESM-only/two-entry-point setup
 - `README.md`: list the `Signal` and `Effect` class exports in "API at a glance"
 - `CONTRIBUTING.md`: add `skills/using-signalize/` and `CLAUDE.md` to the documentation structure table
+- `README.md`, `skills/using-signalize`: correct the cleanup claim — `SignalGroup` has a `FinalizationRegistry` backstop for groups with a host object, so "nothing is garbage-collected for you" was wrong; document its three limits (non-deterministic firing, no coverage for self-keyed groups or unattached resources)
 
 ## `v0.30.0` (2026-05-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Documentation
+
+- `skills/using-signalize`: split into a lean `SKILL.md` (mental model + six silent-failure behaviours) plus `references/{api,pitfalls,patterns}.md` loaded on demand; sharpen the frontmatter description for triggering
+- `skills/using-signalize/SKILL.md`: drop the "refuse / rewrite" framing in favour of a judgement section — the skill states behaviour, it does not prescribe architecture
+- `CLAUDE.md`: trim to the resident subset (commands, non-derivable gotchas, changelog rules) and point to `AGENTS.md`, `skills/` and `docs/` for the rest
+- `CLAUDE.md`, `AGENTS.md`: remove the stale claim that the `skills/` folder was removed — it exists and is part of the doc-sync chain
+- `AGENTS.md`: document the skill in the documentation surface, de-duplicate the CI-vs-local section
+- `README.md`: add an "AI coding agents" pointer to the shipped skill
+
 ## `v0.30.0` (2026-05-20)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 - `CLAUDE.md`, `AGENTS.md`: remove the stale claim that the `skills/` folder was removed — it exists and is part of the doc-sync chain
 - `AGENTS.md`: document the skill in the documentation surface, de-duplicate the CI-vs-local section
 - `README.md`: add an "AI coding agents" pointer to the shipped skill
+- `README.md`: add a "Development" section (pnpm task overview, and why `pnpm world` — not `pnpm cbt` — is the pre-push gate)
+- `README.md`: add a "Good to know" section listing the six behaviours that differ from other signal libraries without raising an error
+- `README.md`: fix the batched-writes example — a `createMemo` result is called as `total()`, it has no `.get()`
+- `README.md`: fix the domain-model example — `createMemo` was used but not imported
+- `README.md`: install snippet now installs the `@spearwolf/eventize` peer dependency explicitly (pnpm/yarn do not add peers), and notes the ESM-only/two-entry-point setup
+- `README.md`: list the `Signal` and `Effect` class exports in "API at a glance"
+- `CONTRIBUTING.md`: add `skills/using-signalize/` and `CLAUDE.md` to the documentation structure table
 
 ## `v0.30.0` (2026-05-20)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,55 +1,54 @@
 # CLAUDE.md
 
-Operational guidance for Claude Code in this repo. **Architecture, eventize internals, source-file map, and full public API surface are in `AGENTS.md` — read it before any non-trivial change.**
+`@spearwolf/signalize` — synchronous signals/effects/memos/links on top of `@spearwolf/eventize`. ESM-only, Node `>=24.13`, ES2023.
 
-## Project
+## Where the knowledge lives
 
-`@spearwolf/signalize` — synchronous signals/effects/memos/links library on top of `@spearwolf/eventize`. ESM-only, Node `>=24.13`, ES2023.
+| Need | Read |
+| --- | --- |
+| Architecture, eventize internals, source-file map, full public API, common change patterns | `AGENTS.md` — read before any non-trivial change |
+| How to *use* signalize (mental model, pitfalls, patterns) | `skills/using-signalize/` |
+| Behaviour details and quirks | `docs/` (`api.md`, `recipes.md`, `architecture.md`, `cheat-sheet.md`) |
+
+Everything below is the short list that is expensive to discover by reading code.
 
 ## Commands
 
-Package manager: **pnpm** (`pnpm@10.6.5`). Never `npm install`.
+Package manager is **pnpm** (`pnpm@10.6.5`) — never `npm install`.
 
-| Command | Runs |
-| --- | --- |
-| `pnpm cbt` | `clean + compile + bundle + test` — local "done" gate |
-| `pnpm world` | `clean + check + compile + bundle + test` — matches CI scope |
-| `pnpm test` | Jest (ts-jest, ESM) |
-| `pnpm test -- <file>` | single spec, e.g. `pnpm test -- createSignal.spec.ts` |
-| `pnpm test -- -t "<name>"` | filter by test name |
-| `pnpm check` / `pnpm fix` | Biome lint+format / Biome auto-fix |
-| `pnpm lint` | Biome lint only |
-| `pnpm format:write` | Biome format auto-fix |
-| `pnpm bundle` | rollup → `dist/` |
-| `pnpm compile` | tsc → `lib/` (types + sourcemaps) |
-| `pnpm checkPkgTypes` | `attw --pack` |
+- `pnpm cbt` — clean + compile + bundle + test. The local "done" gate.
+- `pnpm world` — adds `check`; **this is what matches CI** (`.github/workflows/ci.yml` runs `check + test`, not `cbt`).
+- `pnpm test -- <file>` / `pnpm test -- -t "<name>"` — single spec / by test name.
+- `pnpm fix` — Biome lint+format auto-fix.
 
-**CI ≠ `pnpm cbt`.** `.github/workflows/ci.yml` runs `check + test`. Use `pnpm world` to match CI locally.
+Full command table in `AGENTS.md`.
 
-## Repo quirks (gotchas, not derivable from code)
+## Things the code won't tell you
 
-- **Imports use `.js` extension** in `src/` (NodeNext): `import {x} from './foo.js'` — even though the source is `foo.ts`. Always.
-- **`strict: true` but `strictNullChecks: false`** in `tsconfig.json` — intentional. Don't add `?:` defensively to "fix" null errors that aren't errors here.
-- **Decorators are TC39 standard** (no `experimentalDecorators`). Use the `accessor` keyword and standard descriptor signatures, not legacy TS decorator forms.
-- **Linting & formatting via Biome** (`biome.json`). ESLint and Prettier are gone. Disabled rules of note: `noUnsafeDeclarationMerging`, `noConstructorReturn`, `noTsIgnore`, `noAsyncPromiseExecutor`, `useArrowFunction` — all match intentional patterns in this codebase.
-- **TypeScript 6 needs explicit `types`** in `tsconfig.json` (`["jest", "node"]`); auto-include from `node_modules/@types/*` no longer fires here. Removing it breaks `assert-helpers.ts` (uses Jest globals).
-- **Edit only `src/`.** `lib/` (tsc) and `dist/` (rollup) are generated; don't commit.
-- **Tests are `*.spec.ts` adjacent** to implementation. Jest is rooted at `src/` only.
-- **`sideEffects: false`** — keep modules side-effect-free at top level (tree-shaking).
-- **Public API surface lives in `src/index.ts` (default entry) and `src/decorators.ts` (`./decorators` subpath).** A new file in `src/` is invisible to consumers until re-exported through one of these.
+- **Imports carry a `.js` extension** in `src/` (NodeNext): `import {x} from './foo.js'` even though the source is `foo.ts`. Always.
+- **`strict: true` but `strictNullChecks: false`** is intentional. Null-ish values are passed around freely; don't add defensive `?:` to "fix" errors that aren't errors here.
+- **Decorators are TC39 standard** (no `experimentalDecorators`) — `accessor` keyword, standard descriptor signatures.
+- **Biome only** (`biome.json`); ESLint and Prettier are gone. The disabled rules (`noUnsafeDeclarationMerging`, `noConstructorReturn`, `noTsIgnore`, `noAsyncPromiseExecutor`, `useArrowFunction`) each match a deliberate pattern in this codebase.
+- **TypeScript 6 needs the explicit `types: ["jest", "node"]`** in `tsconfig.json`; auto-include from `node_modules/@types/*` no longer fires. Removing it breaks `assert-helpers.ts`.
+- **Edit only `src/`.** `lib/` (tsc) and `dist/` (rollup) are generated — never commit them.
+- **A new file in `src/` is invisible to consumers** until re-exported through `src/index.ts` (default entry) or `src/decorators.ts` (`./decorators` subpath).
+- Tests are `*.spec.ts` adjacent to the implementation; Jest is rooted at `src/` only.
+- `sideEffects: false` — keep module top-levels side-effect-free so tree-shaking holds.
 
 ## Verifying subscription leaks
 
-For changes that touch subscribe/unsubscribe paths, assert no listener leaks. `src/assert-helpers.ts` (test-only) provides `getSubscriptionCount(queue, event?)`. Combine with public counters `getSignalsCount`, `getEffectsCount`, `getLinksCount`. Pattern: snapshot baseline → run scenario → destroy → assert restored. See `unsubscribeEffect.spec.ts`.
+For changes touching subscribe/unsubscribe paths, assert that nothing leaks: snapshot `getSubscriptionCount(queue, event?)` (from the test-only `src/assert-helpers.ts`) together with `getSignalsCount` / `getEffectsCount` / `getLinksCount` → run the scenario → destroy → assert restored. `unsubscribeEffect.spec.ts` is the reference.
 
-## Documentation sync
+## When the public API changes
 
-Public-API changes → `src/*.ts` JSDoc → `docs/api.md` → `docs/recipes.md` (if a quirk/pattern is involved) → `docs/cheat-sheet.md` → `README.md` "API at a glance" → `CHANGELOG.md`. The previous top-level `skills/` folder was removed (commit `f08fb05`) — ignore older references to `SKILL.md` updates. Older doc filenames (`introduction.md`, `guide.md`, `full-api.md`) were superseded; do not recreate them.
+Sync in this order: source JSDoc → `docs/api.md` → `docs/recipes.md` (if a quirk or pattern is involved) → `docs/cheat-sheet.md` → `skills/using-signalize/` (`SKILL.md` for the mental model and the top-six list, `references/` for the detail) → `README.md` "API at a glance" → `CHANGELOG.md`.
+
+Older doc filenames (`introduction.md`, `guide.md`, `full-api.md`) were superseded — don't recreate them.
 
 ## CHANGELOG discipline
 
-Every user-visible change (features, fixes, deps, build-system, breaking changes) gets an entry under `## Unreleased` in `CHANGELOG.md`. Pure internal refactors with no observable effect can be skipped.
+Every user-visible change (features, fixes, deps, build system, breaking changes) gets an entry under `## Unreleased`. Pure internal refactors with no observable effect can be skipped.
 
-- **Items must be short and precise** — one line, one fact. No wordy prose, no rationale paragraphs, no "why" essays. If context is needed, link a commit/PR; don't expand the line.
-- **Never modify entries under released version headings** (`## v0.x.y`). Past releases are immutable history. Corrections go into a new `## Unreleased` entry.
-- Group under existing `### Build System` / `### Bug Fixes` / `### Tests` / `### Documentation` / `### Chores` headings; create a new one only if none fit.
+- One line, one fact. If context is needed, link a commit or PR rather than expanding the line.
+- **Never modify entries under released headings** (`## v0.x.y`) — past releases are immutable. Corrections become a new `## Unreleased` entry.
+- Group under the existing `### Build System` / `### Bug Fixes` / `### Tests` / `### Documentation` / `### Chores` headings; add a new one only when none fits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,9 @@ When changing the public API:
 | `docs/api.md`           | Complete API reference                       |
 | `docs/recipes.md`       | Patterns, quirks, gotchas                    |
 | `docs/cheat-sheet.md`   | One-page lookup                              |
+| `skills/using-signalize/` | Agent skill shipped to consumers            |
 | `AGENTS.md`             | AI assistant context (internal architecture) |
+| `CLAUDE.md`             | Claude Code operational notes                |
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -92,11 +92,16 @@ Runs anywhere modern JavaScript runs. Targets ES2023, requires Node `>=24.13`.
 
 ## Install
 
+[`@spearwolf/eventize`](https://github.com/spearwolf/eventize) 🏹 is a peer dependency — install it alongside, since pnpm and yarn do not add peers automatically:
+
 ```shell
-npm install @spearwolf/signalize
+# pick one
+npm install  @spearwolf/signalize @spearwolf/eventize
+pnpm add     @spearwolf/signalize @spearwolf/eventize
+yarn add     @spearwolf/signalize @spearwolf/eventize
 ```
 
-[`@spearwolf/eventize`](https://github.com/spearwolf/eventize) 🏹 is a peer dependency.
+ESM-only: there is no CommonJS build. Two entry points — `@spearwolf/signalize` and `@spearwolf/signalize/decorators`.
 
 ## API at a glance
 
@@ -124,9 +129,14 @@ SignalGroup, getSignalGroupsCount, SignalAutoMap
 findObjectSignalByName, findObjectSignals, findObjectSignalNames,
 destroyObjectSignals
 
+// classes — for `instanceof` checks and as types
+Signal, Effect
+
 // decorators (subpath: '@spearwolf/signalize/decorators')
 signal, memo
 ```
+
+Every option and type is in the [API reference](./docs/api.md).
 
 ## Examples
 
@@ -163,7 +173,7 @@ const price = createSignal(100);
 const qty   = createSignal(1);
 const total = createMemo(() => price.get() * qty.get());
 
-createEffect(() => console.log('total =', total.get()));
+createEffect(() => console.log('total =', total()));
 // => "total = 100"
 
 batch(() => {
@@ -204,7 +214,7 @@ adapter, a Vue component, a Web Component, or a plain DOM render — none of
 them have to know about each other.
 
 ```typescript
-import {createSignal, createEffect} from '@spearwolf/signalize';
+import {createSignal, createMemo, createEffect} from '@spearwolf/signalize';
 
 export function createCart() {
   const items = createSignal<Item[]>([]);
@@ -253,6 +263,28 @@ class Counter {
 > The decorator API uses TC39 standard decorators (no `experimentalDecorators`).
 > Memos created via `@memo` are always lazy.
 
+## Good to know
+
+Six things that differ from most other signal libraries. None of them raise an
+error — they just quietly do something else, so they are worth reading once.
+
+- **`set()` takes a value, not an updater.** `count.set(v => v + 1)` stores the
+  *function*; write `count.set(count.value + 1)`.
+- **`.get()` tracks, `.value` does not.** Reading `.value` inside an effect
+  gives you an effect that never re-runs. That is also how you read
+  deliberately *without* subscribing.
+- **`createSignal` returns an object, `createMemo` returns a function.**
+  So it is `count.get()` but `total()`.
+- **Static deps switch off auto-tracking *and* autorun.**
+  `createEffect(cb, [a, b])` does not run on creation, and signals read inside
+  the callback are not subscribed — call `eff.run()` for an initial pass.
+- **`@memo()` is always lazy**, so dependent effects are not notified when its
+  inputs change. Use `createMemo(..., {attach: this})` for an eager class memo.
+- **Cleanup is manual.** Effects and links outlive the scope that created them:
+  pass `{attach: obj}` and dispose with `SignalGroup.delete(obj)`.
+
+The full list lives in [Recipes & quirks](./docs/recipes.md).
+
 ## Documentation
 
 | Document                                  | Purpose                                     |
@@ -268,6 +300,38 @@ For changes between releases, see [CHANGELOG.md](./CHANGELOG.md).
 ### AI coding agents
 
 The package ships an agent skill at [`skills/using-signalize/`](./skills/using-signalize) that teaches Claude Code (and compatible agents) the mental model, the behaviours that silently produce wrong reactive code, and the idiomatic patterns. See its [README](./skills/using-signalize/README.md) for install options.
+
+## Development
+
+The package manager is **pnpm** (`pnpm@10.6.5`); `npm install` is not supported
+here. Node `>=24.13` is required to build.
+
+```shell
+git clone https://github.com/spearwolf/signalize.git
+cd signalize
+pnpm install
+```
+
+| Task | Runs |
+| --- | --- |
+| `pnpm test` | Jest via ts-jest, with coverage gate |
+| `pnpm test -- <file>` | A single spec, e.g. `pnpm test -- createSignal.spec.ts` |
+| `pnpm test -- -t "<name>"` | Only tests whose name matches |
+| `pnpm check` / `pnpm fix` | Biome lint + format — check only / auto-fix |
+| `pnpm compile` | `tsc` → `lib/` (types + sourcemaps) |
+| `pnpm bundle` | rollup → `dist/` |
+| `pnpm clean` | Remove build artifacts |
+| `pnpm cbt` | clean + compile + bundle + test |
+| `pnpm world` | clean + **check** + compile + bundle + test |
+
+**Which one to use:** `pnpm test` while iterating, and `pnpm world` before
+pushing — it is the only task that also runs Biome, which is what CI checks
+(`pnpm check && pnpm test`). `pnpm cbt` skips the linter, so a green `cbt` can
+still fail CI.
+
+Tests are `*.spec.ts` files sitting next to the implementation in `src/`; only
+`src/` is edited by hand, `lib/` and `dist/` are generated. Details and code
+style are in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ class Counter {
 
 For changes between releases, see [CHANGELOG.md](./CHANGELOG.md).
 
+### AI coding agents
+
+The package ships an agent skill at [`skills/using-signalize/`](./skills/using-signalize) that teaches Claude Code (and compatible agents) the mental model, the behaviours that silently produce wrong reactive code, and the idiomatic patterns. See its [README](./skills/using-signalize/README.md) for install options.
+
 ## Contributing
 
 Issues and pull requests are welcome. See

--- a/README.md
+++ b/README.md
@@ -280,8 +280,11 @@ error — they just quietly do something else, so they are worth reading once.
   the callback are not subscribed — call `eff.run()` for an initial pass.
 - **`@memo()` is always lazy**, so dependent effects are not notified when its
   inputs change. Use `createMemo(..., {attach: this})` for an eager class memo.
-- **Cleanup is manual.** Effects and links outlive the scope that created them:
-  pass `{attach: obj}` and dispose with `SignalGroup.delete(obj)`.
+- **Cleanup is explicit.** Effects and links outlive the scope that created
+  them: pass `{attach: obj}` and dispose with `SignalGroup.delete(obj)`. Groups
+  attached to a host object do have a `FinalizationRegistry` backstop that
+  clears them once the object is unreachable, but GC timing is unobservable —
+  it is insurance against a leak, not a disposal schedule.
 
 The full list lives in [Recipes & quirks](./docs/recipes.md).
 

--- a/skills/using-signalize/README.md
+++ b/skills/using-signalize/README.md
@@ -1,15 +1,31 @@
 # using-signalize — Skill
 
 A Claude Code / Claude Agent skill that primes an AI coding agent with the
-public API, mental model, and quirks of [`@spearwolf/signalize`](https://github.com/spearwolf/signalize).
+mental model, quirks, and public API of [`@spearwolf/signalize`](https://github.com/spearwolf/signalize).
 The skill activates whenever an agent sees an import from `@spearwolf/signalize`
 or `@spearwolf/signalize/decorators`, or when the user mentions *signalize*
 in their prompt.
 
-The content is targeted at LLMs, not humans: it is dense, table-heavy, and
-front-loads the gotchas that AI coding agents most often get wrong (e.g.
-React-style `set(prev => prev + 1)` updater functions, `.get()` vs `.value`
-tracking, eager vs lazy memos, static-deps disabling autorun).
+The content is targeted at LLMs, not humans. It is organised for progressive
+disclosure: `SKILL.md` stays short and front-loads the handful of behaviours
+that silently produce wrong code (React-style `set(prev => prev + 1)` updater
+functions, `.get()` vs `.value` tracking, eager vs lazy memos, static deps
+disabling autorun, manual cleanup), and the bulk of the material sits in
+reference files the agent reads only when a task needs them:
+
+| File | Contents |
+| --- | --- |
+| `SKILL.md` | Mental model, the six silent-failure behaviours, pointers |
+| `references/api.md` | Full signatures, options, and exports per entry point |
+| `references/pitfalls.md` | The complete annotated quirk list |
+| `references/patterns.md` | Idiomatic patterns and common rewrites |
+
+Install the whole folder, not just `SKILL.md` — the references are resolved
+relative to it.
+
+The skill describes how signalize behaves; it deliberately avoids prescribing
+an application architecture, so it should not fight your project's own
+conventions.
 
 For the human-facing documentation see the project [`docs/`](../../docs) folder.
 
@@ -70,14 +86,11 @@ Start a new Claude Code session in the project and ask:
 which skills do you have available?
 ```
 
-`using-signalize` should appear in the list. You can also force-invoke it:
-
-```
-/skill using-signalize
-```
-
-If the skill is installed correctly, the agent will load this `SKILL.md` and
-acknowledge `signalize` context before continuing.
+`using-signalize` should appear in the list. You can also ask for it by name
+("use the using-signalize skill"). If the skill is installed correctly, the
+agent loads `SKILL.md` and acknowledges the `signalize` context before
+continuing — and pulls in `references/` on its own when a task calls for the
+detail.
 
 ## Uninstall
 

--- a/skills/using-signalize/SKILL.md
+++ b/skills/using-signalize/SKILL.md
@@ -18,7 +18,7 @@ import {signal, memo} from '@spearwolf/signalize/decorators';
 - Propagation is **synchronous and inline**. `signal.set(x)` runs every dependent effect *before it returns*. No scheduler, no microtask queue, no tearing — and no free debounce.
 - Effects subscribe **on read**: calling `sig.get()` inside the callback registers the dependency. Deps are recomputed every run, so they may grow or shrink.
 - Memos are signals driven by a high-priority (`1000`) effect, so they settle before ordinary effects.
-- Nothing is garbage-collected for you. Signals, effects and links live until destroyed — usually via the `attach` option plus `SignalGroup.delete(obj)`.
+- Lifecycles are explicit. Signals, effects and links live until destroyed — normally via the `attach` option plus `SignalGroup.delete(obj)`. A group attached to a host object additionally has a `FinalizationRegistry` backstop, but it is leak insurance, not a lifecycle (see behaviour 5).
 
 ## Six behaviours that silently produce wrong code
 
@@ -47,7 +47,9 @@ eff.run();   // ✓ call once if an initial pass is wanted
 
 **4 — Lazy memos do not push.** Default `lazy: false` behaves like a computed signal: dependent effects re-run when deps change. With `lazy: true` the memo only recomputes on read and dependents are *not* notified. **The `@memo()` decorator is always lazy** — for an eager class memo use `createMemo(..., {attach: this})`.
 
-**5 — Cleanup is manual.** Effects and links outlive the scope that created them. Pass `{attach: obj}` when creating them and tear down with `SignalGroup.delete(obj)`.
+**5 — Cleanup is explicit.** Effects and links outlive the scope that created them, and an unattached one stays reachable from the global queues indefinitely. Pass `{attach: obj}` at creation and tear down with `SignalGroup.delete(obj)`.
+
+A group *with a host object* also gets a `FinalizationRegistry` backstop: once that object becomes unreachable without an explicit teardown, the group's `clear()` runs and the attached signals, effects and links are reclaimed. It is a genuine safety net, but GC timing is unobservable and it may never fire within a process — so it prevents the worst-case leak rather than defining when cleanup happens. Design for explicit disposal; treat the registry as insurance.
 
 **6 — `createSignal(existingSignal)` is a passthrough.** It returns that same signal — no clone, no new instance. Handy for "value or signal" helpers; wrong if a copy was intended.
 

--- a/skills/using-signalize/SKILL.md
+++ b/skills/using-signalize/SKILL.md
@@ -1,311 +1,80 @@
 ---
 name: using-signalize
-description: Use when code imports `@spearwolf/signalize` or `@spearwolf/signalize/decorators`, mentions `signalize`/`Signalize`, or when writing/reviewing fine-grained reactivity code with signals, effects, memos, links, SignalGroup, or the @signal/@memo decorators. Covers the API surface, the synchronous reactivity model, lifecycle bundles, lazy/eager memos, dynamic vs static effect deps, and the quirks LLMs most often get wrong.
+description: Write, review, or debug code that uses `@spearwolf/signalize` — signals, effects, memos, links, SignalGroup, SignalAutoMap, or the `@signal`/`@memo` decorators. Use when a file imports `@spearwolf/signalize` or `@spearwolf/signalize/decorators`, when the user mentions signalize, or when reactivity built on it misbehaves (effect never re-runs, effect runs too often, memo looks stale, listeners leak). Loads the mental model plus the behaviours that differ from React/Solid/Vue; API, pitfall and pattern references load on demand.
 ---
 
-# @spearwolf/signalize — Quick Reference
+# Using @spearwolf/signalize
 
-Synchronous, fine-grained reactivity. ESM-only, `sideEffects: false`, targets ES2023, runs on Node `>=24.13` or any modern browser. Built on `@spearwolf/eventize` (peer dep). Fully typed for TypeScript.
-
-## Mental model
-
-- Four primitives: **Signal** (reactive value) → **Effect** (auto-rerun) → **Memo** (cached derived signal) → **Link** (one-way data flow). **SignalGroup** owns lifecycles.
-- Everything propagates **synchronously, inline**. `signal.set(x)` runs every dependent effect before returning. No scheduler, no microtask queue.
-- Effects subscribe **on read** (`signal.get()`) within their callback; deps are recomputed every run unless static.
-- Memos are signals driven internally by a high-priority (`1000`) effect, so they resolve before normal effects.
-
-## Two entry points
+Framework-agnostic, **synchronous** fine-grained reactivity. ESM-only, `sideEffects: false`, ES2023, Node `>=24.13` or any modern browser. Peer dep: `@spearwolf/eventize`. Fully typed.
 
 ```ts
-import {/* core */} from '@spearwolf/signalize';
+import {createSignal, createEffect, createMemo, link, SignalGroup} from '@spearwolf/signalize';
 import {signal, memo} from '@spearwolf/signalize/decorators';
 ```
 
-Decorators are TC39 standard form (no `experimentalDecorators`). Use the `accessor` keyword.
+## Mental model
 
-## Public API surface
+- **Signal** (reactive value) → **Effect** (auto-rerun) → **Memo** (cached derived signal) → **Link** (one-way flow). **SignalGroup** owns lifecycles.
+- Propagation is **synchronous and inline**. `signal.set(x)` runs every dependent effect *before it returns*. No scheduler, no microtask queue, no tearing — and no free debounce.
+- Effects subscribe **on read**: calling `sig.get()` inside the callback registers the dependency. Deps are recomputed every run, so they may grow or shrink.
+- Memos are signals driven by a high-priority (`1000`) effect, so they settle before ordinary effects.
+- Nothing is garbage-collected for you. Signals, effects and links live until destroyed — usually via the `attach` option plus `SignalGroup.delete(obj)`.
 
-```ts
-// --- runtime values ---
-// signals
-createSignal, destroySignal, isSignal, muteSignal, unmuteSignal,
-getSignalsCount, touch, value
-// effects
-createEffect, getEffectsCount, onCreateEffect, onDestroyEffect
-// memos
-createMemo
-// links
-link, unlink, getLinksCount
-// context modes
-batch, beQuiet, isQuiet, hibernate
-// lifecycle / collections
-SignalGroup, SignalAutoMap
-// host-object signals
-findObjectSignalByName, findObjectSignals, findObjectSignalNames, destroyObjectSignals
-// classes (exported for `instanceof` and as types)
-Signal, Effect
+## Six behaviours that silently produce wrong code
 
-// --- type-only re-exports (no runtime value) ---
-//   SignalReader, SignalWriter, SignalLike, SignalParams, SignalWriterParams,
-//   EffectOptions, EffectCallback, CreateMemoOptions, LinkOptions,
-//   SignalLink, ValueCallback, SignalAutoMapKeyType,
-//   CompareFunc, BeforeReadFunc, VoidFunc, ValueChangedCallback
-```
+These cause no error and no warning. They are the difference between signalize and the signal libraries most code is modelled on.
 
-## Signals
+**1 — `set()` takes a value, never an updater.** A function argument is *stored as the value*, not invoked.
 
 ```ts
-const c = createSignal(0, {
-  lazy:       false,            // true → initial is a factory, evaluated on first read
-  compare:    (a, b) => a===b,  // custom equality (default ===)
-  beforeRead: () => {},         // hook on tracked reads only (NOT on .value)
-  attach:     obj,              // SignalGroup lifecycle
-});
-
-c.get();        // tracked read (registers dep when inside an effect)
-c.value;        // untracked read
-c.set(v);  c.value = v;
-c.set(v, {touch: true});      // notify even if equal
-c.set(fn, {lazy: true});      // factory, evaluated on next read
-c.touch();  c.destroy();  c.muted = true;
-const off = c.onChange(v => …);   // returns unsubscribe
+count.set((v) => v + 1);        // ✗ stores the function
+count.set(count.value + 1);     // ✓
 ```
 
-Helpers: `value(c)` / `value([obj,'prop'])` (untracked), `touch(c)` / `touch([obj,'prop'])` (notify), `isSignal(x)`, `muteSignal(c)`, `unmuteSignal(c)`, `destroySignal(...sigs)`.
-
-## Effects
+**2 — `.get()` tracks, `.value` does not.** Reading `.value` inside an effect creates an effect that never re-runs.
 
 ```ts
-createEffect(() => {
-  use(c.get());
-  return () => cleanup();
-}, {
-  autorun:      true,           // false → manual eff.run()
-  dependencies: [c],            // STATIC deps → disables auto-tracking; does NOT autorun
-  priority:     0,              // higher first
-  attach:       obj,
-});
-
-createEffect(cb, [c]);                      // shorthand → static deps
-createEffect(cb, ['name'], {attach: obj});  // names resolved against group
-
-const eff = createEffect(cb, {autorun: false});
-eff.run();    // runs only if a tracked dep changed since last run
-eff.destroy();
+createEffect(() => render(pos.value));   // ✗ runs once, never again
+createEffect(() => render(pos.get()));   // ✓
 ```
 
-`getEffectsCount()`, `onCreateEffect(cb) → unsub`, `onDestroyEffect(cb) → unsub`.
-
-## Memos
+**3 — Static deps disable autorun *and* auto-tracking.** `createEffect(cb, [a, b])` (or `{dependencies: [...]}`) does not run on creation, and signals read inside the callback are not subscribed — only `a` and `b` trigger reruns.
 
 ```ts
-const m = createMemo(() => a.get() * 2, {
-  lazy:     false,    // true → recompute on read; effects DO NOT re-run on dep change
-  priority: 1000,
-  attach:   obj,
-  name:     'm',
-});
-m();                  // SignalReader<T>
+const eff = createEffect(cb, [a, b]);
+eff.run();   // ✓ call once if an initial pass is wanted
 ```
 
-## Links
+**4 — Lazy memos do not push.** Default `lazy: false` behaves like a computed signal: dependent effects re-run when deps change. With `lazy: true` the memo only recomputes on read and dependents are *not* notified. **The `@memo()` decorator is always lazy** — for an eager class memo use `createMemo(..., {attach: this})`.
 
-```ts
-const con = link(src, target, {attach: obj});  // target: signal | (v) => void
-unlink(src, target);  unlink(src);             // drop one or all
-getLinksCount();  getLinksCount(src);
+**5 — Cleanup is manual.** Effects and links outlive the scope that created them. Pass `{attach: obj}` when creating them and tear down with `SignalGroup.delete(obj)`.
 
-con.lastValue; con.isMuted; con.isDestroyed;
-con.mute(); con.unmute(); con.toggleMute();
-con.touch();  con.destroy();  con.attach(obj);
+**6 — `createSignal(existingSignal)` is a passthrough.** It returns that same signal — no clone, no new instance. Handy for "value or signal" helpers; wrong if a copy was intended.
 
-await con.nextValue();
-for await (const v of con.asyncValues((v,i) => i>=5)) {/* … */}
-```
+## Verifying reactive code
 
-Link emits eventize events on itself: `'value'`, `'mute'`, `'unmute'`, `'destroy'`.
-
-## Context modes
-
-```ts
-batch(() => { a.set(1); b.set(2); });   // dedup + flush in priority order; HINT not guarantee
-beQuiet(() => a.get());                 // reads untracked, writes silent (counter, nests)
-hibernate(() => { /* outer ctx suspended */ });   // batches/quiet/effect-stack saved & restored
-isQuiet();
-```
-
-`hibernate` flushes any active outer batch before running its callback so queued effects aren't lost.
-
-## SignalGroup
-
-```ts
-const g = SignalGroup.findOrCreate(obj);  // throws on null; returns same instance for the same obj
-SignalGroup.get(obj);                     // existing or undefined
-SignalGroup.delete(obj);                  // clear & remove (preferred destructor)
-SignalGroup.clear();                      // global
-
-g.attachSignal(s); g.attachSignalByName('n', s); g.detachSignal(s);
-g.signal('n');           // walks parent chain
-g.hasSignal('n');
-g.attachEffect(e); g.runEffects();
-g.attachLink(l);   g.detachLink(l);
-g.attachGroup(child); g.detachGroup(child);
-g.clear();
-```
-
-Registry is `WeakMap<object, SignalGroup>`; back-pointer is `WeakRef`. Attaching a group to a user object **does not** keep it alive.
-
-## SignalAutoMap
-
-```ts
-const m = new SignalAutoMap();
-const m2 = SignalAutoMap.fromProps({a:1, b:2}, ['a']);
-m.get('k');                              // auto-creates Signal<undefined>
-m.has('k');
-m.update(new Map([['k','v']]));          // batched
-m.updateFromProps(obj, ['k']);           // batched
-for (const k of m.keys()){} for (const s of m.signals()){} for (const [k,s] of m.entries()){}
-m.clear();
-```
-
-## Object signals (used by decorators)
-
-```ts
-findObjectSignalByName(obj, 'prop');    // Signal<T> | undefined
-findObjectSignals(obj);                  // Signal[] | undefined
-findObjectSignalNames(obj);              // (string|symbol)[] | undefined
-destroyObjectSignals(obj1, obj2);        // signals only — for full cleanup use SignalGroup.delete(obj)
-```
-
-## Decorators
-
-```ts
-class Foo {
-  @signal({                       // accessor REQUIRED
-    name:        'count',         // override registered name
-    readAsValue: false,           // true → property getter is .value (untracked)
-    compare:     (a,b)=>a===b,
-    beforeRead:  () => {},
-    attach:      something,       // override default group (the instance)
-  }) accessor count = 0;
-
-  @memo({name:'doubled'})         // ALWAYS lazy; attached to instance group
-  doubled() { return this.count * 2; }
-}
-// Cleanup: SignalGroup.delete(instance)  -- or destroyObjectSignals(instance) for signals-only
-```
-
-Each instance gets its own per-property signal. `@memo` is always lazy — for an eager class memo use `createMemo()` directly.
-
-## ⚠️ Quirks & pitfalls (LLMs commonly get these wrong)
-
-1. **No React-style updater function.** `signal.set((v) => v+1)` stores the **function** as the value, it is not invoked. TypeScript blocks this for typed code; `any`/untyped paths slip through. Use `signal.set(signal.value + 1)`.
-
-2. **`signal.get()` tracks, `signal.value` does not.** Top-level reactivity bug source: writing `c.value` inside an effect when you meant `c.get()` results in an effect that never re-runs.
-
-3. **Static deps disable autorun AND auto-tracking.** `createEffect(cb, [a, b])` does NOT run on creation — call `.run()` once if you need the initial pass. Signals read inside the callback are NOT subscribed; only `[a,b]` trigger reruns. The same is true for `{dependencies: [...]}`.
-
-4. **Lazy is not sticky.** `createSignal(fn, {lazy:true})` is lazy until first read. After a non-lazy `set(v)` the signal stays non-lazy. Pass `{lazy:true}` again to re-lazy. Likewise, calling `set(fn)` (without `{lazy:true}`) stores the function as the value.
-
-5. **`createSignal(otherSignal)` is a passthrough.** It returns the existing signal — no new signal, no counter increment. Useful for "value or signal" helpers; do NOT assume it cloned.
-
-6. **Memo eager vs lazy changes downstream behaviour.** Default `lazy:false` makes the memo a computed signal: dependent effects re-run on dep change. With `lazy:true`, dependent effects do NOT re-run on dep change; the memo is only recomputed on read. **`@memo()` is always lazy.**
-
-7. **Synchronous self-write recursion is bounded.** If an effect callback writes to a signal it depends on, `run()` re-enters synchronously. Capped at `EffectImpl.maxDepth = 256`; beyond that throws a descriptive `Error` (not a stack overflow). Prefer breaking the cycle (`beQuiet` for self-writes, conditional guard, split effect). Tune `EffectImpl.maxDepth = N` only when intentional.
-
-8. **`signalReader(callback)` is deprecated.** `sig.get(cb)` creates an internal effect with no unsubscribe handle — only destroying the signal cleans it up. Emits a once-per-process `console.warn`. Use `sig.onChange(cb)` (returns an unsubscribe).
-
-9. **`batch()` is a HINT, not a guarantee.** Most flushes are deduplicated and priority-ordered, but internal consistency rules can still cause partial propagation. Don't rely on "exactly one effect run per batch" as a correctness invariant.
-
-10. **`beforeRead` only fires on tracked reads.** Including `sig.get()` and the deprecated `sig.get(cb)` form. `.value` / `value(sig)` skip it. Don't use `beforeRead` for invariants you need on every observation.
-
-11. **`set(v, {touch:true})` is suppressed on muted/destroyed signals.** Same for `signal.touch()`. If you need to force-emit on a muted signal, unmute first.
-
-12. **Nested effects are recreated on every parent rerun.** Order on a re-run: parent's own cleanup → child effects destroyed (each child's cleanup runs as part of its destroy) → parent callback re-executes → fresh inner effects created. Don't capture the inner `Effect` handle in long-lived state.
-
-13. **Dynamic deps can shrink between runs.** Signals read in run N but not in run N+1 are unsubscribed at the end of run N+1. Conditional `if (a.get()) b.get()` is fine — that's the whole point of dynamic tracking.
-
-14. **`SignalGroup.findOrCreate(group)` returns the group itself.** Passing an existing `SignalGroup` is a no-op identity. `findOrCreate(null)` throws.
-
-15. **`SignalGroup.delete(obj)` ≠ `g.clear()`.** They both clear; the static form also looks the group up by the user object first. The instance method `destroy()` is deprecated and warns — use `clear()`.
-
-16. **Same `(source, target)` pair? `link()` returns the existing link.** It is deduplicated; do not assume each call creates a new SignalLink. The link is auto-destroyed when source OR (signal-)target is destroyed.
-
-17. **`SignalAutoMap` retains destroyed signals.** If you call `destroySignal()` on an entry, the map keeps it: reads return last value, writes are silent no-ops. Prefer `map.clear()` or attach signals to a SignalGroup.
-
-18. **Decorator memos have their own group.** `@signal` and `@memo` register against `SignalGroup.findOrCreate(this)`. Cleanup with `SignalGroup.delete(this)` (full) or `destroyObjectSignals(this)` (signals only — leaves attached effects/links alive).
-
-19. **In-source imports use `.js` extension** (NodeNext resolution): `import {x} from './foo.js'` even when the source is `foo.ts`. This affects code you write *inside* the package; consumers don't care.
-
-20. **No async by default.** Effect callbacks may be async, and a returned cleanup will be called when the promise settles, but propagation itself is synchronous. There is no `microtask` debounce — write your own if needed.
-
-## Idiomatic patterns
-
-### Lifecycle-bundled component
-
-```ts
-class Player {
-  health = createSignal(100, {attach: this});
-  pos    = createSignal({x:0,y:0}, {attach: this});
-
-  constructor() {
-    createEffect(() => render(this.pos.get()), {attach: this});
-    link(this.health, (v) => v <= 0 && this.die(), {attach: this});
-  }
-  destroy() { SignalGroup.delete(this); }   // tears down signals + effects + links
-}
-```
-
-### Frame-paced effect
-
-```ts
-const eff = createEffect(render, {autorun: false});
-const tick = () => { updateState(); eff.run(); requestAnimationFrame(tick); };
-requestAnimationFrame(tick);
-```
-
-### Computed in a chain
-
-```ts
-const items = createSignal<Item[]>([]);
-const visible = createMemo(() => items.get().filter(x => x.visible));   // eager
-const count   = createMemo(() => visible().length);                      // eager, depends on memo
-createEffect(() => render(count()));   // re-runs when count() changes
-```
-
-### Decorator class with eager memo
-
-```ts
-class Cart {
-  @signal() accessor items: Item[] = [];
-
-  // Eager — must use createMemo because @memo is always lazy
-  total = createMemo(() => this.items.reduce((s, x) => s + x.price, 0), {attach: this});
-
-  destroy() { SignalGroup.delete(this); }
-}
-```
-
-### Leak check in tests
+The library exports live counters. In tests, snapshot → run → destroy → assert restored; a mismatch is a leak:
 
 ```ts
 const baseline = [getSignalsCount(), getEffectsCount(), getLinksCount()];
-// run scenario, destroy/clear
+// … build, use, and tear down the scenario …
 expect([getSignalsCount(), getEffectsCount(), getLinksCount()]).toEqual(baseline);
 ```
 
-## When NOT to reach for signalize
+## Reference files
 
-- You need cross-process or async-by-default state → use a real state store / message bus.
-- You need built-in time travel / undo / devtools → pick a state library that ships them.
-- One-off "callback when X changes" with no graph of derivations → `signal.onChange(cb)` is fine, but consider plain eventize.
+Read these when the task needs them — they are not loaded upfront.
 
-## Anti-patterns to refuse / rewrite
+| File | Read it when |
+| --- | --- |
+| `references/api.md` | Looking up exact signatures, options, or what is exported from which entry point |
+| `references/pitfalls.md` | Behaviour is surprising, or reviewing code for subtle reactivity bugs — the full annotated list, of which the six above are the most common |
+| `references/patterns.md` | Structuring something new: lifecycle bundles, frame-paced effects, derivation chains, decorator classes, and the idiomatic rewrite of each anti-pattern |
 
-- `signal.set(prev => prev + 1)` — not an updater. Rewrite as `signal.set(signal.value + 1)`.
-- `signal.get(callback)` for subscriptions — deprecated. Rewrite as `signal.onChange(callback)`.
-- `createSignal(...).value = …` immediately followed by `createEffect(() => …signal.value…)` — effect won't track. Use `signal.get()`.
-- `createEffect(cb, [a])` without a follow-up `.run()` when an initial pass is needed.
-- Manually re-implementing memo with `createEffect` writing to a signal — use `createMemo` (priority + cache for free).
-- `tsconfig.json` with `experimentalDecorators: true` for the `@signal`/`@memo` decorators — they require the standard form.
-- Forgetting to destroy effects/links — track via `SignalGroup` from the start, not retroactively.
+The project's own `docs/` folder (`api.md`, `recipes.md`, `architecture.md`, `cheat-sheet.md`) goes deeper still when it is available.
+
+## Judgement
+
+This skill describes how signalize behaves, not a house style. Synchronous inline propagation, manual lifecycles and explicit `attach` are the library's design, so code that ignores them tends to leak or go stale — but how to structure an application on top is an open question. Prefer the user's existing conventions, and treat the items above as facts to design around rather than rules to enforce.
+
+Signalize is a poor fit for cross-process or async-first state, for built-in time-travel/devtools, and for a single "call me when X changes" with no derivation graph (`sig.onChange(cb)` or plain eventize is simpler there). Say so rather than forcing it.

--- a/skills/using-signalize/references/api.md
+++ b/skills/using-signalize/references/api.md
@@ -170,6 +170,8 @@ g.clear();          // full teardown
 
 The registry is a `WeakMap<object, SignalGroup>` and the back-pointer to the host object is a `WeakRef` — attaching a group does **not** keep the host object alive.
 
+A group created against a host object is also registered with a `FinalizationRegistry`; if that object becomes unreachable without an explicit `SignalGroup.delete(obj)` / `group.clear()`, the callback runs `clear()`. Self-keyed groups (`object === this`) are not registered. FR timing is non-deterministic — see pitfall 16a.
+
 ## SignalAutoMap
 
 ```ts

--- a/skills/using-signalize/references/api.md
+++ b/skills/using-signalize/references/api.md
@@ -1,0 +1,223 @@
+# API reference — `@spearwolf/signalize`
+
+Signatures and options. For *why* something behaves as it does see `pitfalls.md`.
+
+## Entry points
+
+```ts
+import {/* core */} from '@spearwolf/signalize';
+import {signal, memo} from '@spearwolf/signalize/decorators';
+```
+
+Decorators are **TC39 standard** form — no `experimentalDecorators`, and the `accessor` keyword is required on `@signal`.
+
+### Exported from `@spearwolf/signalize`
+
+```ts
+// signals
+createSignal, destroySignal, isSignal, muteSignal, unmuteSignal,
+getSignalsCount, touch, value
+// effects
+createEffect, getEffectsCount, onCreateEffect, onDestroyEffect
+// memos
+createMemo
+// links
+link, unlink, getLinksCount
+// context modes
+batch, beQuiet, isQuiet, hibernate
+// lifecycle / collections
+SignalGroup, getSignalGroupsCount, SignalAutoMap
+// host-object signals
+findObjectSignalByName, findObjectSignals, findObjectSignalNames, destroyObjectSignals
+// classes (for `instanceof` and as types)
+Signal, Effect
+
+// type-only re-exports (no runtime value):
+//   SignalReader, SignalWriter, SignalLike, SignalParams, SignalWriterParams,
+//   EffectOptions, EffectCallback, CreateMemoOptions, LinkOptions,
+//   SignalLink, ValueCallback, SignalAutoMapKeyType,
+//   CompareFunc, BeforeReadFunc, VoidFunc, ValueChangedCallback
+```
+
+### Exported from `@spearwolf/signalize/decorators`
+
+```ts
+signal, memo
+// types: SignalDecoratorOptions, SignalReaderDecoratorOptions, MemoDecoratorOptions
+```
+
+## Signals
+
+```ts
+const c = createSignal(0, {
+  lazy:       false,              // true → `initial` is a factory, evaluated on first read
+  compare:    (a, b) => a === b,  // custom equality (default: ===)
+  beforeRead: () => {},           // hook, tracked reads only (NOT on .value)
+  attach:     obj,                // SignalGroup lifecycle
+});
+
+c.get();                    // tracked read — registers a dependency inside an effect
+c.value;                    // untracked read
+c.set(v);   c.value = v;    // write
+c.set(v, {touch: true});    // notify even when equal
+c.set(fn, {lazy: true});    // store a factory, evaluate on next read
+c.touch();                  // force-notify
+c.destroy();
+c.muted = true;             // muted signals neither notify nor touch
+const off = c.onChange((v) => {});   // → unsubscribe function
+```
+
+Top-level helpers:
+
+```ts
+value(c);   value([obj, 'prop']);   // untracked read
+touch(c);   touch([obj, 'prop']);   // force-notify
+isSignal(x);
+muteSignal(c);  unmuteSignal(c);
+destroySignal(...signals);
+getSignalsCount();
+```
+
+## Effects
+
+```ts
+createEffect(() => {
+  use(c.get());
+  return () => cleanup();       // optional cleanup, runs before each rerun and on destroy
+}, {
+  autorun:      true,           // false → run manually via eff.run()
+  dependencies: [c],            // STATIC deps → disables auto-tracking; does NOT autorun
+  priority:     0,              // higher runs first
+  attach:       obj,
+});
+
+createEffect(cb, [c]);                       // shorthand → static deps
+createEffect(cb, ['name'], {attach: obj});   // names resolved against the group
+
+const eff = createEffect(cb, {autorun: false});
+eff.run();       // runs only if a tracked dep changed since the last run
+eff.destroy();
+```
+
+String/symbol dependency names require `attach` — the pairing is checked at compile time.
+
+```ts
+getEffectsCount();
+onCreateEffect((eff) => {});   // → unsubscribe
+onDestroyEffect((eff) => {});  // → unsubscribe
+
+EffectImpl.maxDepth = 256;     // synchronous self-write recursion guard
+```
+
+## Memos
+
+```ts
+const m = createMemo(() => a.get() * 2, {
+  lazy:     false,   // true → recompute on read; dependent effects do NOT re-run
+  priority: 1000,
+  attach:   obj,
+  name:     'm',     // group registration name
+});
+m();                 // SignalReader<T>
+```
+
+## Links
+
+```ts
+const con = link(src, target, {attach: obj});   // target: signal | (value) => void
+unlink(src, target);   unlink(src);             // drop one, or all links from src
+getLinksCount();       getLinksCount(src);
+
+con.lastValue;  con.isMuted;  con.isDestroyed;
+con.mute();  con.unmute();  con.toggleMute();
+con.touch();  con.destroy();  con.attach(obj);
+
+await con.nextValue();
+for await (const v of con.asyncValues((v, i) => i >= 5)) { /* … */ }
+```
+
+A link is an eventize object and emits `'value'`, `'mute'`, `'unmute'`, `'destroy'` on itself.
+
+## Context modes
+
+```ts
+batch(() => { a.set(1); b.set(2); });   // dedup + flush in priority order — a HINT, not a guarantee
+beQuiet(() => a.get());                 // reads untracked, writes silent; counter-based, nests
+hibernate(() => { /* outer reactive context suspended */ });
+isQuiet();
+```
+
+`hibernate` flushes an active outer batch before running its callback, so queued effects are not lost, and restores batches / quiet state / effect stack afterwards.
+
+## SignalGroup
+
+```ts
+const g = SignalGroup.findOrCreate(obj);   // throws on null; same instance per obj
+SignalGroup.get(obj);                       // existing group or undefined
+SignalGroup.delete(obj);                    // clear & remove — the preferred destructor
+SignalGroup.clear();                        // global reset
+getSignalGroupsCount();
+
+g.attachSignal(s);  g.attachSignalByName('n', s);  g.detachSignal(s);
+g.signal('n');      // walks the parent chain
+g.hasSignal('n');
+g.attachEffect(e);  g.runEffects();
+g.attachLink(l);    g.detachLink(l);
+g.attachGroup(child);  g.detachGroup(child);
+g.off();            // destroy attached effects/links, drop external subs, KEEP signals
+g.clear();          // full teardown
+```
+
+The registry is a `WeakMap<object, SignalGroup>` and the back-pointer to the host object is a `WeakRef` — attaching a group does **not** keep the host object alive.
+
+## SignalAutoMap
+
+```ts
+const m = new SignalAutoMap();
+const m2 = SignalAutoMap.fromProps({a: 1, b: 2}, ['a']);
+
+m.get('k');                          // auto-creates Signal<undefined>
+m.has('k');
+m.update(new Map([['k', 'v']]));     // batched
+m.updateFromProps(obj, ['k']);       // batched
+for (const k of m.keys()) {}
+for (const s of m.signals()) {}
+for (const [k, s] of m.entries()) {}
+m.clear();
+```
+
+## Object signals
+
+Signals stored on a host object and retrievable by property name — the mechanism behind the decorators.
+
+```ts
+findObjectSignalByName(obj, 'prop');   // Signal<T> | undefined
+findObjectSignals(obj);                // Signal[] | undefined
+findObjectSignalNames(obj);            // (string | symbol)[] | undefined
+destroyObjectSignals(obj1, obj2);      // signals only — full cleanup is SignalGroup.delete(obj)
+```
+
+## Decorators
+
+```ts
+class Foo {
+  @signal({                     // `accessor` is REQUIRED
+    name:        'count',       // override the registered name
+    readAsValue: false,         // true → the property getter is .value (untracked)
+    compare:     (a, b) => a === b,
+    beforeRead:  () => {},
+    attach:      something,     // override the default group (the instance)
+  }) accessor count = 0;
+
+  @memo({name: 'doubled'})      // ALWAYS lazy; attached to the instance group
+  doubled() { return this.count * 2; }
+}
+```
+
+Every instance gets its own per-property signal. Cleanup: `SignalGroup.delete(instance)` for everything, or `destroyObjectSignals(instance)` for signals only.
+
+## Counters
+
+```ts
+getSignalsCount();  getEffectsCount();  getLinksCount();  getSignalGroupsCount();
+```

--- a/skills/using-signalize/references/patterns.md
+++ b/skills/using-signalize/references/patterns.md
@@ -1,0 +1,106 @@
+# Patterns — `@spearwolf/signalize`
+
+Shapes that work well with the library's design. They are starting points, not a mandated style — an existing codebase's conventions win.
+
+## Lifecycle-bundled component
+
+The default way to own reactive state: create everything with `{attach: this}`, tear it all down in one call.
+
+```ts
+class Player {
+  health = createSignal(100, {attach: this});
+  pos    = createSignal({x: 0, y: 0}, {attach: this});
+
+  constructor() {
+    createEffect(() => render(this.pos.get()), {attach: this});
+    link(this.health, (v) => v <= 0 && this.die(), {attach: this});
+  }
+
+  destroy() { SignalGroup.delete(this); }   // signals + effects + links
+}
+```
+
+Group hierarchies compose: `parentGroup.attachGroup(childGroup)` makes the child's teardown part of the parent's.
+
+## Frame-paced effect
+
+Propagation is synchronous, so pacing is the caller's job. An `autorun: false` effect only actually re-runs when a tracked dep changed since the last run, which makes it cheap to call every frame.
+
+```ts
+const eff = createEffect(render, {autorun: false});
+
+const tick = () => {
+  updateState();
+  eff.run();
+  requestAnimationFrame(tick);
+};
+requestAnimationFrame(tick);
+```
+
+## Derivation chain
+
+Eager memos push; chain them and let a single effect sit at the end.
+
+```ts
+const items   = createSignal<Item[]>([]);
+const visible = createMemo(() => items.get().filter((x) => x.visible));   // eager
+const count   = createMemo(() => visible().length);                       // eager, reads a memo
+createEffect(() => render(count()));                                      // re-runs when count() changes
+```
+
+## Decorator class with an eager memo
+
+```ts
+class Cart {
+  @signal() accessor items: Item[] = [];
+
+  // Eager — createMemo, because @memo is always lazy
+  total = createMemo(() => this.items.reduce((s, x) => s + x.price, 0), {attach: this});
+
+  destroy() { SignalGroup.delete(this); }
+}
+```
+
+## Coalescing several writes
+
+```ts
+batch(() => {
+  a.set(1);
+  b.set(2);
+});   // dedup + priority-ordered flush (a hint, not a guarantee — see pitfalls.md)
+```
+
+## Pausing without destroying
+
+`g.off()` destroys attached effects and links and drops external subscriptions while keeping the signals and their values, so the group can be repopulated later. `g.clear()` is the full teardown.
+
+## Leak check in tests
+
+```ts
+const baseline = [getSignalsCount(), getEffectsCount(), getLinksCount()];
+// build, exercise, and tear down the scenario
+expect([getSignalsCount(), getEffectsCount(), getLinksCount()]).toEqual(baseline);
+```
+
+Inside the signalize repo itself, `src/assert-helpers.ts` adds `getSubscriptionCount(queue, event?)` for per-queue subscription assertions.
+
+## Common rewrites
+
+Code shaped by other signal libraries usually needs one of these. Each left-hand form is silently wrong rather than an error, so it is worth flagging on review.
+
+| Instead of | Write |
+| --- | --- |
+| `signal.set((prev) => prev + 1)` | `signal.set(signal.value + 1)` — `set` takes a value |
+| `signal.get(callback)` | `signal.onChange(callback)` — returns an unsubscribe handle |
+| `createEffect(() => use(sig.value))` | `createEffect(() => use(sig.get()))` — `.value` does not track |
+| `createEffect(cb, [a])` when an initial pass is needed | add `eff.run()` once — static deps do not autorun |
+| A `createEffect` that writes its result into a signal | `createMemo` — priority and caching come for free |
+| `@memo()` where dependents must react | `createMemo(..., {attach: this})` — `@memo` is always lazy |
+| `experimentalDecorators: true` in `tsconfig.json` | TC39 standard decorators — `@signal` needs the `accessor` keyword |
+| Creating effects/links and destroying them by hand later | `{attach: obj}` from the start, then `SignalGroup.delete(obj)` |
+
+## Where signalize is the wrong tool
+
+- Cross-process or async-first state → a real store or message bus.
+- Built-in time travel, undo, or devtools → a library that ships them.
+- A single "call me when X changes" with no derivation graph → `signal.onChange(cb)` works, but plain `@spearwolf/eventize` is simpler.

--- a/skills/using-signalize/references/pitfalls.md
+++ b/skills/using-signalize/references/pitfalls.md
@@ -1,0 +1,59 @@
+# Pitfalls — `@spearwolf/signalize`
+
+Behaviours that surprise people (and models) coming from React, Solid, Vue or MobX. Most fail *silently*: no error, no warning, just an effect that never fires or a value that never updates. The first six are also summarised in `SKILL.md`.
+
+## Reading and writing
+
+**1 — `set()` takes a value, not an updater.** `signal.set((v) => v + 1)` stores the **function** as the value; it is never invoked. TypeScript rejects this on typed signals, but `any` and untyped paths slip through. Use `signal.set(signal.value + 1)`.
+
+**2 — `signal.get()` tracks, `signal.value` does not.** The single most common reactivity bug: writing `c.value` inside an effect callback when `c.get()` was meant produces an effect that runs once and never again. Conversely, `.value` is the correct tool for deliberately reading without subscribing.
+
+**3 — `beforeRead` fires on tracked reads only.** That includes `sig.get()` and the deprecated `sig.get(cb)` form. `.value` and `value(sig)` skip it. Do not put invariants there that must hold on *every* observation.
+
+**4 — Lazy is not sticky.** `createSignal(fn, {lazy: true})` stays lazy only until the first read. After a plain `set(v)` the signal is non-lazy; pass `{lazy: true}` again to restore it. And `set(fn)` *without* `{lazy: true}` stores the function as the value (see pitfall 1).
+
+**5 — `createSignal(otherSignal)` is a passthrough.** It returns the existing signal — no new signal, no counter increment. Useful for "accept a value or a signal" helpers; wrong if a copy was intended.
+
+**6 — `set(v, {touch: true})` is suppressed on muted or destroyed signals.** So is `signal.touch()`. Unmute first if a forced emit is genuinely needed.
+
+## Effects
+
+**7 — Static deps disable autorun *and* auto-tracking.** `createEffect(cb, [a, b])` — and equally `{dependencies: [a, b]}` — does not run at creation time, and signals read inside the callback are not subscribed. Only the listed deps trigger reruns. Call `.run()` once when an initial pass is wanted.
+
+**8 — Dynamic deps may shrink between runs.** Signals read in run N but not in run N+1 are unsubscribed at the end of run N+1. `if (a.get()) b.get()` is entirely fine — conditional subscription is the point of dynamic tracking.
+
+**9 — Synchronous self-write recursion is bounded, not forbidden.** An effect that writes a signal it depends on re-enters `run()` synchronously. The depth is capped at `EffectImpl.maxDepth = 256`; beyond that a descriptive `Error` is thrown rather than a stack overflow. Prefer breaking the cycle — `beQuiet` around the self-write, a conditional guard, or splitting the effect. Raise `EffectImpl.maxDepth` only when the recursion is intentional.
+
+**10 — Nested effects are recreated on every parent rerun.** Order on a rerun: parent's own cleanup → child effects destroyed (each child's cleanup runs as part of its destroy) → parent callback re-executes → fresh inner effects created. Do not stash an inner `Effect` handle in long-lived state.
+
+**11 — Async callbacks do not make propagation async.** An effect callback may be `async`, and a returned cleanup is called when the promise settles, but propagation itself stays synchronous. There is no microtask debounce; write one if the use case needs it.
+
+## Memos
+
+**12 — Eager vs lazy changes downstream behaviour.** Default `lazy: false` makes the memo a computed signal: dependent effects re-run when its deps change. With `lazy: true` dependents are **not** notified — the memo is only recomputed when read. **`@memo()` is always lazy**; use `createMemo()` directly for an eager class memo.
+
+## Batching and context modes
+
+**13 — `batch()` is a hint, not a guarantee.** Most flushes are deduplicated and priority-ordered, but internal consistency rules can still cause partial propagation. "Exactly one effect run per batch" is not a correctness invariant to build on.
+
+## Lifecycles
+
+**14 — `SignalGroup.findOrCreate(group)` returns the group itself.** Passing an existing `SignalGroup` is an identity no-op. `findOrCreate(null)` throws.
+
+**15 — `SignalGroup.delete(obj)` ≠ `g.clear()`.** Both clear; the static form additionally looks the group up by the host object. `g.off()` is the softer variant — it destroys attached effects and links and drops external subscriptions but keeps the signals alive. The instance method `destroy()` is deprecated and warns; use `clear()`.
+
+**16 — Attaching a group does not keep the host object alive.** The registry is a `WeakMap` and the back-pointer a `WeakRef`, by design.
+
+**17 — `link()` deduplicates by `(source, target)` pair.** Calling it twice with the same pair returns the *existing* link rather than creating a second one. Links auto-destroy when the source or a signal target is destroyed.
+
+**18 — `SignalAutoMap` retains destroyed signals.** Calling `destroySignal()` on an entry leaves it in the map: reads return the last value and writes are silent no-ops. Prefer `map.clear()`, or attach the signals to a `SignalGroup`.
+
+**19 — Decorator signals live in the instance's group.** `@signal` and `@memo` register against `SignalGroup.findOrCreate(this)`. Full cleanup is `SignalGroup.delete(this)`; `destroyObjectSignals(this)` clears signals only and leaves attached effects and links running.
+
+## Deprecated surface
+
+**20 — `signal.get(callback)` is deprecated.** It creates an internal effect with no unsubscribe handle, so only destroying the signal cleans it up, and it emits a once-per-process `console.warn`. Use `sig.onChange(cb)`, which returns an unsubscribe function.
+
+## Working inside the signalize repo
+
+**21 — In-source imports carry a `.js` extension** (NodeNext resolution): `import {x} from './foo.js'` even though the source file is `foo.ts`. This applies to code written *inside* the package; consumers are unaffected.

--- a/skills/using-signalize/references/pitfalls.md
+++ b/skills/using-signalize/references/pitfalls.md
@@ -44,6 +44,12 @@ Behaviours that surprise people (and models) coming from React, Solid, Vue or Mo
 
 **16 — Attaching a group does not keep the host object alive.** The registry is a `WeakMap` and the back-pointer a `WeakRef`, by design.
 
+**16a — There *is* a GC backstop, but do not rely on it.** `SignalGroup` registers its host object with a `FinalizationRegistry`; when that object becomes unreachable without an explicit `SignalGroup.delete(obj)` or `group.clear()`, the callback runs `clear()` and the attached signals, effects and links are reclaimed. Three limits make it insurance rather than a lifecycle:
+
+- FR callbacks fire non-deterministically and may never run before the process exits, so nothing observable is guaranteed at any point in time.
+- It only covers resources reachable through a group with a *host object*. A self-keyed group (`findOrCreate()` with no argument, where `object === this`) is deliberately not registered, and anything created without `attach` is owned by nobody — it stays subscribed to the global queues until destroyed by hand.
+- Because timing is unobservable, leak assertions in tests must still use explicit teardown plus the counters; a passing `getSignalsCount()` check cannot be attributed to the registry.
+
 **17 — `link()` deduplicates by `(source, target)` pair.** Calling it twice with the same pair returns the *existing* link rather than creating a second one. Links auto-destroy when the source or a signal target is destroyed.
 
 **18 — `SignalAutoMap` retains destroyed signals.** Calling `destroySignal()` on an entry leaves it in the map: reads return the last value and writes are silent no-ops. Prefer `map.clear()`, or attach the signals to a `SignalGroup`.


### PR DESCRIPTION
Reworks the agent-facing documentation along Anthropic's Claude 5 context-engineering guidance, then reviews `README.md` for completeness and currency.

> **Note on the source:** `claude.com`, `x.com` and `anthropic.com` all return 403 through this environment's network proxy, so the blog post could not be read in full. The guidance below was reconstructed from search-result summaries. The load-bearing principles were consistently attested; individual phrasings of the original are unknown.

## Agent instructions

| Principle | Applied as |
| --- | --- |
| One fact, one place | The command table, repo conventions and doc-sync chain were duplicated across `CLAUDE.md` and `AGENTS.md` |
| Progressive disclosure | `SKILL.md` went from 311 lines to 80, plus three reference files read only when a task needs them |
| Don't overconstrain | The "anti-patterns to refuse" list became a rewrite table plus a judgement section |
| Descriptions drive triggering | The skill's frontmatter now also names symptoms ("effect never re-runs", "memo looks stale", "listeners leak") |

**The notable fix:** both `CLAUDE.md` and `AGENTS.md` claimed the `skills/` folder had been removed in `f08fb05` and instructed agents to ignore references to `SKILL.md` updates. It was re-added in `40e2979`. Every agent was therefore told not to maintain the skill that ships in the npm package. Corrected, and `skills/` is now part of the doc-sync chain.

### Skill layout

- `SKILL.md` — mental model, the six behaviours that silently produce wrong code, pointer table
- `references/api.md` — signatures, options, exports per entry point
- `references/pitfalls.md` — the full annotated quirk list
- `references/patterns.md` — idioms and common rewrites

`SignalGroup#off()` and `getSignalGroupsCount()` were in `docs/cheat-sheet.md` but missing from the skill; both are now covered and were verified against `src/SignalGroup.ts`.

## README review

Two examples were broken:

- the batched-writes example called `total.get()` on a `createMemo` result — `SignalReader<T>` is callable and has no `.get()`, so this was a type error and a runtime `TypeError`. Now `total()`.
- the domain-model example used `createMemo` without importing it.

Gaps closed:

- the install snippet installed only the package, while `@spearwolf/eventize` is a peer dependency that pnpm and yarn do not add automatically
- "API at a glance" omitted the `Signal` and `Effect` class exports
- no mention of the shipped agent skill
- no developer overview

Added:

- **Good to know** — the six behaviours that differ from other signal libraries without raising an error (`set()` is not an updater, `.get()` tracks and `.value` does not, `createSignal` returns an object while `createMemo` returns a function, static deps disable autorun and tracking, `@memo` is always lazy, cleanup is manual)
- **Development** — the pnpm task table, and the point that `pnpm world` rather than `pnpm cbt` is the pre-push gate, because only `world` runs Biome and CI runs `check && test`

## Verification

Markdown only. `biome.json` scopes Biome to `.ts`/`.mjs`/`.cjs`/`.js`, so `pnpm check` cannot be affected by this diff; it was not run here (`node_modules` absent, and the container has Node 22 against the required `>=24.13`). API claims in the new files were checked against `src/types.ts`, `src/createMemo.ts` and `src/SignalGroup.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzYmcH4DTRaGxmeeXuxCn9)_